### PR TITLE
Add :before_disable, :after_disable, :before_enable, :after_enable callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Zhong.schedule do
     puts "#{job} ran?: #{ran}"
   end
 
+  on(:before_disable) do |job|
+    puts "#{job} is going to be disabled"
+  end
+
+  on(:after_disable) do |job|
+    puts "#{job} disabled"
+  end
+
+  on(:before_enable) do |job|
+    puts "#{job} is going to be enabled"
+  end
+
+  on(:after_enable) do |job|
+    puts "#{job} enabled"
+  end
+
   error_handler do |e, job|
     puts "dang, #{job} messed up: #{e}"
   end

--- a/lib/zhong/scheduler.rb
+++ b/lib/zhong/scheduler.rb
@@ -44,7 +44,7 @@ module Zhong
     def every(period, name, opts = {}, &block)
       raise "must specify a period for #{name} (#{caller.first})" unless period
 
-      job = Job.new(name, opts.merge(@config).merge(every: period, category: @category), &block)
+      job = Job.new(name, opts.merge(@config).merge(every: period, category: @category), @callbacks, &block)
 
       raise "duplicate job #{job}" if jobs.key?(job.id)
 
@@ -57,7 +57,7 @@ module Zhong
     end
 
     def on(event, &block)
-      raise "unknown callback #{event}" unless [:before_tick, :after_tick, :before_run, :after_run].include?(event.to_sym)
+      raise "unknown callback #{event}" unless [:before_tick, :after_tick, :before_run, :after_run, :before_disable, :after_disable, :before_enable, :after_enable].include?(event.to_sym)
       (@callbacks[event.to_sym] ||= []) << block
     end
 

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -32,8 +32,13 @@ class TestWeb < Minitest::Test
   end
 
   def test_disable_job
+    test_before_disable = 0
+    test_after_disable = 0
+
     Zhong.schedule do
       every(30.seconds, "test_disable_web_job") { nil }
+      on(:before_disable) { test_before_disable += 1 }
+      on(:after_disable) { test_after_disable += 1 }
     end
 
     job = Zhong.scheduler.find_by_name("test_disable_web_job")
@@ -48,11 +53,18 @@ class TestWeb < Minitest::Test
     assert_contains "every 30 seconds", last_response.body
     assert_contains 'name="enable"', last_response.body
     assert_equal true, job.disabled?
+    assert_equal 1, test_before_disable
+    assert_equal 1, test_after_disable
   end
 
   def test_enable_job
+    test_before_enable = 0
+    test_after_enable = 0
+
     Zhong.schedule do
       every(12.hours, "test_enable_web_job") { nil }
+      on(:before_enable) { test_before_enable += 1 }
+      on(:after_enable) { test_after_enable += 1 }
     end
 
     job = Zhong.scheduler.find_by_name("test_enable_web_job")
@@ -67,6 +79,8 @@ class TestWeb < Minitest::Test
     assert_contains "every 12 hours", last_response.body
     assert_contains 'name="disable"', last_response.body
     assert_equal false, job.disabled?
+    assert_equal 1, test_before_enable
+    assert_equal 1, test_after_enable
   end
 
   def test_heartbeat


### PR DESCRIPTION
```ruby

Zhong.schedule do

  on(:before_disable) do |job|
    puts "#{job} is going to be disabled"
  end

  on(:after_disable) do |job|
    puts "#{job} disabled"
  end

  on(:before_enable) do |job|
    puts "#{job} is going to be enabled"
  end

  on(:after_enable) do |job|
    puts "#{job} enabled"
  end

end
```