### PR TITLE
Remove hyphen from erb template

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -70,7 +70,7 @@
         <tbody>
           <% @jobs.each do |job| %>
             <% enabled = !@disabled[job.to_s] %>
-            <% enabled_str = enabled ? 'disable' : 'enable' -%>
+            <% enabled_str = enabled ? 'disable' : 'enable' %>
             <% last_run = @last_runs[job.to_s] %>
             <tr class="<%= enabled ? "" : "disabled" %>">
               <td><%= h(job) %></td>
@@ -88,7 +88,7 @@
                 <form method="POST" style="margin-top: 20px; margin-bottom: 10px;">
                   <%= csrf_tag %>
                   <div>
-                    <button type="submit" name="<%= enabled_str -%>" value="<%= job.id -%>" data-confirm="Are you sure you want to <%= enabled_str -%> this job?"><%= enabled_str.capitalize -%></button>
+                    <button type="submit" name="<%= enabled_str %>" value="<%= job.id %>" data-confirm="Are you sure you want to <%= enabled_str %> this job?"><%= enabled_str.capitalize %></button>
                   </div>
                 </form>
               </td>
@@ -100,15 +100,15 @@
     <div>
       <h3>Hosts</h3>
       <ul>
-      <% @hosts.each do |host| -%>
+      <% @hosts.each do |host| %>
         <li>
-          <strong><%= h(host[:host]) -%></strong> <em>(PID <%= host[:pid] -%>)</em>: last seen <%= relative_time(host[:last_seen]) -%>.
+          <strong><%= h(host[:host]) %></strong> <em>(PID <%= host[:pid] %>)</em>: last seen <%= relative_time(host[:last_seen]) %>.
         </li>
-      <% end -%>
+      <% end %>
       </ul>
     </div>
     <div>
-      <small><%= product_version -%></small>
+      <small><%= product_version %></small>
     </div>
   </body>
 </html>


### PR DESCRIPTION
I'm seeing the following error from `tilt` when I try to load the Sinatra web app:

```
2017-10-04 10:25:54 - SyntaxError - /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:73: syntax error, unexpected ';'
bled ? 'disable' : 'enable' -; @_out_buf.concat "\n"
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:91: syntax error, unexpected ')'
ut_buf.concat(( enabled_str -).to_s); @_out_buf.concat "\" v
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:91: syntax error, unexpected ')'
; @_out_buf.concat(( job.id -).to_s); @_out_buf.concat "\" d
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:91: syntax error, unexpected ')'
ut_buf.concat(( enabled_str -).to_s); @_out_buf.concat " thi
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:91: syntax error, unexpected ')'
at(( enabled_str.capitalize -).to_s); @_out_buf.concat "</bu
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:103: syntax error, unexpected ';'
  ";  @hosts.each do |host| -; @_out_buf.concat "\n"
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:105: syntax error, unexpected ')'
buf.concat(( h(host[:host]) -).to_s); @_out_buf.concat "</st
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:105: syntax error, unexpected ')'
out_buf.concat(( host[:pid] -).to_s); @_out_buf.concat ")</e
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:105: syntax error, unexpected ')'
tive_time(host[:last_seen]) -).to_s); @_out_buf.concat ".\n"
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:107: syntax error, unexpected ';'
t_buf.concat "      ";  end -; @_out_buf.concat "\n"
                              ^
/Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/web/views/index.erb:111: syntax error, unexpected ')'
uf.concat(( product_version -).to_s); @_out_buf.concat "</sm
                              ^:
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:274:in `class_eval'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:274:in `compile_template_method'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:236:in `block in compiled_method'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:235:in `synchronize'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:235:in `compiled_method'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:169:in `evaluate'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/tilt-2.0.8/lib/tilt/template.rb:109:in `render'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:839:in `render'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:682:in `erb'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/zhong-0.2.3/lib/zhong/web.rb:40:in `block in <class:Web>'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1632:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1632:in `block in compile!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:991:in `block (3 levels) in route!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1010:in `route_eval'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:991:in `block (2 levels) in route!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1037:in `block in process_route'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1035:in `catch'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1035:in `process_route'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:989:in `block in route!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:988:in `each'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:988:in `route!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1094:in `block in dispatch!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1073:in `block in invoke'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1073:in `catch'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1073:in `invoke'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1091:in `dispatch!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:923:in `block in call!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1073:in `block in invoke'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1073:in `catch'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1073:in `invoke'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:923:in `call!'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:913:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/honeybadger-3.1.2/lib/honeybadger/rack/error_notifier.rb:34:in `block in call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/honeybadger-3.1.2/lib/honeybadger/agent.rb:321:in `with_rack_env'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/honeybadger-3.1.2/lib/honeybadger/rack/error_notifier.rb:31:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/xss_header.rb:18:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/path_traversal.rb:16:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/json_csrf.rb:26:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/frame_options.rb:31:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/xss_header.rb:18:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/path_traversal.rb:16:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/json_csrf.rb:26:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/base.rb:50:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-protection-2.0.0/lib/rack/protection/frame_options.rb:31:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/session/abstract/id.rb:232:in `context'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/session/abstract/id.rb:226:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/null_logger.rb:9:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/head.rb:12:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/show_exceptions.rb:22:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:194:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1955:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1499:in `block in call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1726:in `synchronize'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:1499:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/tempfile_reaper.rb:15:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/lint.rb:49:in `_call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/lint.rb:37:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/show_exceptions.rb:23:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/common_logger.rb:33:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sinatra-2.0.0/lib/sinatra/base.rb:231:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/chunked.rb:54:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/content_length.rb:15:in `call'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rack-2.0.3/lib/rack/handler/webrick.rb:86:in `service'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/2.4.0/webrick/httpserver.rb:140:in `service'
        /Users/brianstorti/.rbenv/versions/2.4.2/lib/ruby/2.4.0/webrick/httpserver.rb:96:in `run'
```

This can be reproduced with this code:

```ruby
# Gemfile
ruby '2.4.2'

gem 'sinatra'
gem 'zhong'
```

```ruby
# config.ru
require 'zhong/web'

run Zhong::Web
```

```
$ bundle && bundle exec rackup
```

The error seems to be caused by the hyphen in the `erb` closing tag (`-%>`), and removing it solves the problem without changing how the template is rendered.