### PR TITLE
Support owner for jobs in clock files

### DIFF
--- a/lib/zhong/job.rb
+++ b/lib/zhong/job.rb
@@ -199,6 +199,5 @@ module Zhong
       @with_ownership_class.method(@with_ownership_method)
     rescue NameError => e
     end
-
   end
 end

--- a/lib/zhong/job.rb
+++ b/lib/zhong/job.rb
@@ -21,8 +21,10 @@ module Zhong
 
       @if = config[:if]
       @long_running_timeout = config[:long_running_timeout]
+      @with_ownership_class = config[:with_ownership_class] # class
+      @with_ownership_method = config[:with_ownership_method] # symbol
       @owner = config[:owner]
-      @with_owner = @owner.present? && self.class.rollbar_with_owner_method.present?
+      @with_owner = @owner.present? && rollbar_with_owner_method.present?
       @running = false
       @first_run = true
       @last_ran = nil
@@ -194,7 +196,7 @@ module Zhong
     end
 
     def self.rollbar_with_owner_method
-      Object.const_get("Rollbar").method(:with_owner)
+      @with_ownership_class.method(@with_ownership_method)
     rescue NameError => e
     end
 

--- a/lib/zhong/job.rb
+++ b/lib/zhong/job.rb
@@ -69,7 +69,7 @@ module Zhong
           if @block
             begin
               if with_owner
-                self.class.rollbar_with_owner_method.call(owner, &@block)
+                rollbar_with_owner_method.call(owner, &@block)
               else
                 @block.call
               end
@@ -195,7 +195,7 @@ module Zhong
       @lock ||= Suo::Client::Redis.new(lock_key, client: redis, stale_lock_expiration: @long_running_timeout)
     end
 
-    def self.rollbar_with_owner_method
+    def rollbar_with_owner_method
       @with_ownership_class.method(@with_ownership_method)
     rescue NameError => e
     end

--- a/lib/zhong/job.rb
+++ b/lib/zhong/job.rb
@@ -3,7 +3,7 @@ module Zhong
     extend Forwardable
     def_delegators Zhong, :redis, :tz, :logger, :heartbeat_key
 
-    attr_reader :name, :category, :last_ran, :at, :every, :id, :owner
+    attr_reader :name, :category, :last_ran, :at, :every, :id, :owner, :with_owner
 
     def initialize(job_name, config = {}, callbacks = {}, &block)
       @name = job_name

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -78,7 +78,7 @@ class TestJob < Minitest::Test
     @@calls = Hash.new { |h, k| h[k] = 0 }
 
     def self.with_my_owner(owner, &block)
-      &block.call
+      block.call
       @calls[owner]++
     end
 

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -78,7 +78,7 @@ class TestJob < Minitest::Test
     @@calls = Hash.new { |h, k| h[k] = 0 }
 
     def self.with_my_owner(owner, &block)
-      @calls[owner] += 1
+      @@calls[owner] += 1
 
       block.call
     end

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -78,8 +78,9 @@ class TestJob < Minitest::Test
     @@calls = Hash.new { |h, k| h[k] = 0 }
 
     def self.with_my_owner(owner, &block)
+      @calls[owner] += 1
+
       block.call
-      @calls[owner]++
     end
 
     def self.calls(owner)
@@ -89,27 +90,9 @@ class TestJob < Minitest::Test
 
 
   def test_owner
-
-
-    Kernel.const_set "Rollbar", Class.new do
-      @with_owner_calls = {}
-      define_singleton_method :with_owner_calls do
-        @with_owner_calls
-      end
-
-      define_singleton_method :with_owner do |owner|
-        yield
-        @with_owner_calls[:owner] ||= 0
-        @with_owner_calls[:owner] += 1
-      end
-    end
-
-    with_ownership_class = MyRollbar
-    with_ownership_method = :with_my_owner
-
     with_owner_config = test_default_config.merge(
-      with_ownership_class: with_ownership_class,
-      with_ownership_method: with_ownership_method
+      with_ownership_class: MyRollbar,
+      with_ownership_method: :with_my_owner
     )
 
     success_counter = Queue.new

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -62,6 +62,7 @@
           <tr>
             <th>Job</th>
             <th style="width: 15%;">Scheduled</th>
+            <th style="width: 15%;">Owner</th>
             <th style="width: 15%;">Last Run</th>
             <th style="width: 15%;">Next Run</th>
             <th style="width: 15%;">Action</th>
@@ -82,6 +83,7 @@
                   at <%= job.at %>
                 <% end %>
               </td>
+              <td><%= job.owner.presence || "default" %></td>
               <td><%= relative_time(last_run ? Time.at(last_run.to_i) : nil) %></td>
               <td><%= relative_time(job.next_at) %></td>
               <td>


### PR DESCRIPTION
Support providing with_ownership configuration:

```
Zhong.Scheduler.new(
     with_ownership_class: Rollbar,
     with_ownership_method: :with_owner
).do 

   every(1.day, 'growth job', at:'10:30', owner: :growth) do
       GrowthJob.perform_later
   end
end
```