### PR TITLE
Make schedules with #at: more stable

### DIFF
--- a/lib/zhong/job.rb
+++ b/lib/zhong/job.rb
@@ -12,7 +12,7 @@ module Zhong
       @config = config
       @callbacks = callbacks
 
-      @at = config[:at] ? At.parse(config[:at], grace: config.fetch(:grace, 15.minutes)) : nil
+      @at = config[:at] ? At.parse(config[:at], grace: config.fetch(:grace, 0.minutes)) : nil
       @every = config[:every] ? Every.parse(config[:every]) : nil
 
       raise "must specific either `at` or `every` for job: #{self}" unless @at || @every
@@ -171,7 +171,7 @@ module Zhong
     end
 
     def run_at?(time)
-      !@at || @at.next_at(time) <= time
+      !@at || @at.next_at(@last_ran) <= time
     end
 
     def run_if?(time)

--- a/lib/zhong/scheduler.rb
+++ b/lib/zhong/scheduler.rb
@@ -7,7 +7,7 @@ module Zhong
 
     DEFAULT_CONFIG = {
       timeout: 0.5,
-      grace: 15.minutes,
+      grace: 0,
       long_running_timeout: 5.minutes
     }.freeze
 


### PR DESCRIPTION
Fix schedules that have the at: specified, by

- setting grace to zero
- fixing `#run_at?` condition in `Job`

Without this, it was possible for at: schedules to run either more often (using `every 1.minute ... at: '00:30'`) or not at all (using `every 1.day ... at: '00:30'`)