### PR TITLE
Import 'active_support' before any of its subparts

### DIFF
--- a/lib/zhong.rb
+++ b/lib/zhong.rb
@@ -4,6 +4,7 @@ require "logger"
 require "msgpack"
 require "redis"
 require "suo"
+require "active_support"
 require "active_support/time"
 
 require "zhong/version"


### PR DESCRIPTION
**TL;DR**, Fix compatibility with ActiveSupport >7 which now require "active_support" before anything else

# What?
- Add `require "active_support"` before any other active_support requires

# Why?
- Fixes #40
- This issue has been brought to the attention to Rails maintainers, as it has broken a few gems.
    see [this reply from the maintainers](https://github.com/rails/rails/pull/44450#issuecomment-1042012586)
  > you must require "active_support" before requiring any subparts. That may change in the future, but for now that's the fix you are looking for.
- ActiveSupport since v7 auto-loads (lazy-load) all its constants [here](https://github.com/rails/rails/blob/7c2714eec64ec05409863a0cd123bbd565f2bc5d/activesupport/lib/active_support.rb#L51)